### PR TITLE
Task/eparker71/tlt 1873   add guidance text to analytics

### DIFF
--- a/css/analytics_text.css
+++ b/css/analytics_text.css
@@ -1,7 +1,7 @@
 
 /* CSS for text block on analytics page */
 
-#center-alert-info-id {
+.center-alert-info {
 
      width: 100%;
 
@@ -10,7 +10,7 @@
      display: inline-block;
 }
 
-#alert-info-id {
+.alert-info {
 
      background-image: -webkit-linear-gradient(top, #d9edf7 0%, #b9def0 100%);
 

--- a/css/analytics_text.css
+++ b/css/analytics_text.css
@@ -2,41 +2,24 @@
 /* CSS for text block on analytics page */
 
 .center-alert-info {
-
      width: 100%;
-
      text-align: center;
-
      display: inline-block;
 }
 
 .alert-info {
-
      background-image: -webkit-linear-gradient(top, #d9edf7 0%, #b9def0 100%);
-
      background-image: -o-linear-gradient(top, #d9edf7 0%, #b9def0 100%);
-
      background-image: -webkit-gradient(linear, left top, left bottom, from(#d9edf7), to(#b9def0));
-
      background-image: linear-gradient(to bottom, #d9edf7 0%, #b9def0 100%);
-
      filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffd9edf7', endColorstr='#ffb9def0', GradientType=0);
-
      background-repeat: repeat-x;
-
      border-radius: 4px;
-
      border: solid 1px #9acfea;
-
      font-family: Helvetica, Arial, sans-serif;
-
      text-align: center; display: inline-block;
-
      width: 60%;
-
      margin: 1em 0.5em 2% 1em;
-
      padding: 0.5em 2%;
-
 }
 

--- a/css/analytics_text.css
+++ b/css/analytics_text.css
@@ -1,7 +1,7 @@
 
 /* CSS for text block on analytics page */
 
-.center-alert-info {
+#center-alert-info-id {
 
      width: 100%;
 
@@ -10,7 +10,7 @@
      display: inline-block;
 }
 
-.alert-info {
+#alert-info-id {
 
      background-image: -webkit-linear-gradient(top, #d9edf7 0%, #b9def0 100%);
 

--- a/css/analytics_text.css
+++ b/css/analytics_text.css
@@ -1,8 +1,42 @@
-#guidance_text {
-  	font-weight: bold;
-    margin: auto;
-    width: 50%;
-    padding: 10px;
-  	background-color: #d9edf7;
-  	margin-bottom: 1em;
+
+/* CSS for text block on analytics page */
+
+.center-alert-info {
+
+     width: 100%;
+
+     text-align: center;
+
+     display: inline-block;
 }
+
+.alert-info {
+
+     background-image: -webkit-linear-gradient(top, #d9edf7 0%, #b9def0 100%);
+
+     background-image: -o-linear-gradient(top, #d9edf7 0%, #b9def0 100%);
+
+     background-image: -webkit-gradient(linear, left top, left bottom, from(#d9edf7), to(#b9def0));
+
+     background-image: linear-gradient(to bottom, #d9edf7 0%, #b9def0 100%);
+
+     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffd9edf7', endColorstr='#ffb9def0', GradientType=0);
+
+     background-repeat: repeat-x;
+
+     border-radius: 4px;
+
+     border: solid 1px #9acfea;
+
+     font-family: Helvetica, Arial, sans-serif;
+
+     text-align: center; display: inline-block;
+
+     width: 60%;
+
+     margin: 1em 0.5em 2% 1em;
+
+     padding: 0.5em 2%;
+
+}
+

--- a/css/analytics_text.css
+++ b/css/analytics_text.css
@@ -1,6 +1,8 @@
 #guidance_text {
+  	font-weight: bold;
     margin: auto;
-    width: 60%;
-    border:3px solid #8AC007;
+    width: 50%;
     padding: 10px;
+  	background-color: #d9edf7;
+  	margin-bottom: 1em;
 }

--- a/css/analytics_text.css
+++ b/css/analytics_text.css
@@ -1,0 +1,6 @@
+#guidance_text {
+    margin: auto;
+    width: 60%;
+    border:3px solid #8AC007;
+    padding: 10px;
+}

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -27,10 +27,12 @@ function initAnalyticsTextBlock(){
     MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
     var helpMenuObserver = new MutationObserver(function (mutations) {
         mutations.forEach(function (mutation) {
-            var $target = $(mutation.target);
+
+			var $target = $(mutation.target);
             if ($target.find('.course_graphs').length != 0) {
 				console.log($target.html());
             }
+
         });
     });
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,23 +1,25 @@
 
-// get the name of the current page
-var p = window.location.pathname.split("/");
-var filename = p[p.length - 1];
+$(function(){
+	// get the name of the current page
+	var p = window.location.pathname.split("/");
+	var filename = p[p.length - 1];
 
-// if we are on the analytics page display the analytics text block
-if (filename == "analytics") {
+	// if we are on the analytics page display the analytics text block
+	if (filename == "analytics") {
 
-	var guidance_text = '<div class="center-alert-info">' +
-		'	<div class="alert-info">' +
-		'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
-		' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
-		' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
-		'	</div>' +
-		'</div>';
+		var guidance_text = '<div class="center-alert-info">' +
+			'	<div class="alert-info">' +
+			'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
+			' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
+			' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
+			'	</div>' +
+			'</div>';
 
-	// place the text block above the graphs on the page
-	$('.course_graphs').before(guidance_text);
+		// place the text block above the graphs on the page
+		$('.course_graphs').before(guidance_text);
 
-}
+	}
+});
 
 
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -18,4 +18,4 @@ function addAnalyticsText() {
 	}
 }
 
-$(document).ready(addAnalyticsText);
+;$(document).ready(addAnalyticsText);

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -32,7 +32,8 @@ function initAnalyticsTextBlock(){
 
 			if ($target.find('.course_graphs').length != 0) {
 
-				addAnalyticsTextBlock();
+				//addAnalyticsTextBlock();
+				console.log(target.html());
             }
         });
     });

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,5 +1,5 @@
 
-$(document).ready(function() {
+//$(document).ready(function() {
     var p = window.location.pathname.split("/");
     var filename = p[p.length-1];
 
@@ -16,5 +16,5 @@ $(document).ready(function() {
         $('.course_graphs').before(guidance_text);
 
     }
-});
+//});
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,16 +1,20 @@
 
 $(document).ready(function() {
-	var p = window.location.pathname.split("/");
-	var filename = p[p.length-1];
+    var p = window.location.pathname.split("/");
+    var filename = p[p.length-1];
 
-	if(filename == "analytics") {
+    if(filename == "analytics") {
 
-	  var guidance_text = '<p id="guidance_text">The Faculty Oversight Committee on the Access to Electronic Information provides'+ 
-	    ' <a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">guidance to faculty</a>'+
-	    ' on using these analytics.</p>';
+        var guidance_text = '<div class="center-alert-info">' +
+                            '	<div class="alert-info">' +
+                            '		The Faculty Oversight Committee on the Access to Electronic Information provides'+
+                            ' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
+                            ' 		<strong>guidance to faculty</strong></a>'+' on using these analytics.' +
+                            '	</div>' +
+                            '</div>';
 
+        $('.course_graphs').before(guidance_text);
 
-	  $('.course_graphs').before(guidance_text);
-
-	}
+    }
 });
+

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -33,7 +33,7 @@ function initAnalyticsTextBlock(){
 			if ($target.find('.course_graphs').length != 0) {
 
 				//addAnalyticsTextBlock();
-				console.log(target.html());
+				console.log($target.html());
             }
         });
     });

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -2,7 +2,7 @@
 //$(document).ready(function() {
     var p = window.location.pathname.split("/");
     var filename = p[p.length-1];
-
+	console.log('filename:' + filename);
     if(filename == "analytics") {
 
         var guidance_text = '<div class="center-alert-info">' +

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,5 +1,5 @@
 
-$(function(){
+function addAnalyticsTextBlock() {
 	// get the name of the current page
 	var p = window.location.pathname.split("/");
 	var filename = p[p.length - 1];
@@ -19,7 +19,31 @@ $(function(){
 		$('.course_graphs').before(guidance_text);
 
 	}
-});
+}
 
 
+function initAnalyticsTextBlock(){
 
+    MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+    var helpMenuObserver = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+            var $target = $(mutation.target);
+			console.log($target.html());
+            //if ($target.find('.course_graphs').length != 0) {
+
+            //}
+        });
+    });
+
+    var $config = {
+        childList: true,
+        subtree: true,
+        attributes: false,
+        characterData: false,
+    };
+
+    helpMenuObserver.observe(document.body, $config);
+
+}
+
+$(document).ready(initAnalyticsTextBlock);

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -30,10 +30,10 @@ function initAnalyticsTextBlock(){
 
 			var $target = $(mutation.target);
 
-			if ($target.find('.course_graphs').length != 0) {
+			if ($target.find('div.course_graphs').length != 0) {
 
 				//addAnalyticsTextBlock();
-				console.log($target.html());
+				console.log(mutation);
             }
         });
     });

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,19 +1,21 @@
 
-    var p = window.location.pathname.split("/");
-    var filename = p[p.length-1];
+$(document).ready(function() {
+	var p = window.location.pathname.split("/");
+	var filename = p[p.length - 1];
 
-    if(filename == "analytics") {
+	if (filename == "analytics") {
 
-        var guidance_text = '<div class="center-alert-info">' +
-                            '	<div class="alert-info">' +
-                            '		The Faculty Oversight Committee on the Access to Electronic Information provides' +
-                            ' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
-                            ' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
-                            '	</div>' +
-                            '</div>';
+		var guidance_text = '<div class="center-alert-info">' +
+			'	<div class="alert-info">' +
+			'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
+			' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
+			' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
+			'	</div>' +
+			'</div>';
 
-        $('.course_graphs').before(guidance_text);
+		$('.course_graphs').before(guidance_text);
 
-    }
+	}
+});
 
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,13 +1,16 @@
-var p = window.location.pathname.split("/");
-var filename = p[p.length-1];
 
-if(filename == "analytics") {
+$(document).ready(function() {
+	var p = window.location.pathname.split("/");
+	var filename = p[p.length-1];
 
-  var guidance_text = '<p id="guidance_text">The Faculty Oversight Committee on the Access to Electronic Information provides'+ 
-    ' <a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">guidance to faculty</a>'+
-    ' on using these analytics.</p>';
+	if(filename == "analytics") {
+
+	  var guidance_text = '<p id="guidance_text">The Faculty Oversight Committee on the Access to Electronic Information provides'+ 
+	    ' <a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">guidance to faculty</a>'+
+	    ' on using these analytics.</p>';
 
 
-  $('.course_graphs').before(guidance_text);
+	  $('.course_graphs').before(guidance_text);
 
-}
+	}
+});

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -2,11 +2,10 @@
 function addAnalyticsTextBlock() {
 	// get the name of the current page
 	var p = window.location.pathname.split("/");
-	var filename = p[p.length - 1];
+	var resource = p[p.length - 1];
 
 	// if we are on the analytics page display the analytics text block
-	if (filename == "analytics") {
-
+	if (resource == "analytics") {
 		var guidance_text = '<div class="center-alert-info">' +
 			'	<div class="alert-info">' +
 			'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
@@ -24,32 +23,29 @@ function addAnalyticsTextBlock() {
 
 function initAnalyticsTextBlock(){
 
-    MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
-    var analyticsObserver = new MutationObserver(function (mutations) {
-        mutations.forEach(function (mutation) {
-
+	MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+	var analyticsObserver = new MutationObserver(function (mutations) {
+		mutations.forEach(function (mutation) {
+			// check to see if the text block has already been added
 			if( $('.center-alert-info').length == 0) {
-
 				var $target = $(mutation.target);
-
+				// if the course_graphs class exists, the analytics have been loaded
+				// so go ahead and add the text block
 				if ($target.find('.course_graphs').length != 0) {
-
 					addAnalyticsTextBlock();
-					//console.log(mutation);
 				}
-
 			}
-        });
-    });
+		});
+	});
 
-    var $config = {
-        childList: true,
-        subtree: true,
-        attributes: false,
-        characterData: false,
-    };
+	var $config = {
+			childList: true,
+			subtree: true,
+			attributes: false,
+			characterData: false,
+	};
 
-    analyticsObserver.observe(document.body, $config);
+	analyticsObserver.observe(document.body, $config);
 
 }
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -6,8 +6,8 @@ function addAnalyticsTextBlock() {
 
 	// if we are on the analytics page display the analytics text block
 	if (resource == "analytics") {
-		var guidance_text = '<div class="center-alert-info">' +
-			'	<div class="alert-info">' +
+		var guidance_text = '<div id="center-alert-info-id">' +
+			'	<div id="alert-info-id">' +
 			'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
 			' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
 			' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
@@ -27,12 +27,14 @@ function initAnalyticsTextBlock(){
 	var analyticsObserver = new MutationObserver(function (mutations) {
 		mutations.forEach(function (mutation) {
 			// check to see if the text block has already been added
-			if( $('.center-alert-info').length == 0) {
+			if( $('#center-alert-info').length == 0) {
 				var $target = $(mutation.target);
 				// if the course_graphs class exists, the analytics have been loaded
 				// so go ahead and add the text block
 				if ($target.find('.course_graphs').length != 0) {
 					addAnalyticsTextBlock();
+					// remove the observer once we have added the block
+					analyticsObserver.disconnect();
 				}
 			}
 		});

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -25,14 +25,15 @@ function addAnalyticsTextBlock() {
 function initAnalyticsTextBlock(){
 
     MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
-    var helpMenuObserver = new MutationObserver(function (mutations) {
+    var analyticsObserver = new MutationObserver(function (mutations) {
         mutations.forEach(function (mutation) {
 
 			var $target = $(mutation.target);
-            if ($target.find('.course_graphs').length != 0) {
-				console.log($target.html());
-            }
 
+			if ($('#analytics_body').length != 0 && $target.find('.course_graphs').length != 0) {
+
+				addAnalyticsTextBlock();
+            }
         });
     });
 
@@ -43,7 +44,7 @@ function initAnalyticsTextBlock(){
         characterData: false,
     };
 
-    helpMenuObserver.observe(document.body, $config);
+    analyticsObserver.observe(document.body, $config);
 
 }
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -6,8 +6,8 @@ function addAnalyticsTextBlock() {
 
 	// if we are on the analytics page display the analytics text block
 	if (resource == "analytics") {
-		var guidance_text = '<div id="center-alert-info-id">' +
-			'	<div id="alert-info-id">' +
+		var guidance_text = '<div id="analytics-guidance" class="center-alert-info">' +
+			'	<div class="alert-info">' +
 			'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
 			' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
 			' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
@@ -27,7 +27,7 @@ function initAnalyticsTextBlock(){
 	var analyticsObserver = new MutationObserver(function (mutations) {
 		mutations.forEach(function (mutation) {
 			// check to see if the text block has already been added
-			if( $('#center-alert-info').length == 0) {
+			if( $('#analytics-guidance').length == 0) {
 				var $target = $(mutation.target);
 				// if the course_graphs class exists, the analytics have been loaded
 				// so go ahead and add the text block

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,0 +1,13 @@
+var p = window.location.pathname.split("/");
+var filename = p[p.length-1];
+
+if(filename == "analytics") {
+
+  var guidance_text = '<p id="guidance_text">The Faculty Oversight Committee on the Access to Electronic Information provides'+ 
+    ' <a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">guidance to faculty</a>'+
+    ' on using these analytics.</p>';
+
+
+  $('.course_graphs').before(guidance_text);
+
+}

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,5 +1,5 @@
 
-$(document).ready(function() {
+function addAnalyticsText() {
 	var p = window.location.pathname.split("/");
 	var filename = p[p.length - 1];
 
@@ -16,6 +16,6 @@ $(document).ready(function() {
 		$('.course_graphs').before(guidance_text);
 
 	}
-});
+}
 
-
+$(document).ready(addAnalyticsText);

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -7,9 +7,9 @@ $(document).ready(function() {
 
         var guidance_text = '<div class="center-alert-info">' +
                             '	<div class="alert-info">' +
-                            '		The Faculty Oversight Committee on the Access to Electronic Information provides'+
+                            '		The Faculty Oversight Committee on the Access to Electronic Information provides' +
                             ' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
-                            ' 		<strong>guidance to faculty</strong></a>'+' on using these analytics.' +
+                            ' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
                             '	</div>' +
                             '</div>';
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -28,10 +28,9 @@ function initAnalyticsTextBlock(){
     var helpMenuObserver = new MutationObserver(function (mutations) {
         mutations.forEach(function (mutation) {
             var $target = $(mutation.target);
-			console.log($target.html());
-            //if ($target.find('.course_graphs').length != 0) {
-
-            //}
+            if ($target.find('.course_graphs').length != 0) {
+				console.log($target.html());
+            }
         });
     });
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,8 +1,7 @@
 
-//$(document).ready(function() {
     var p = window.location.pathname.split("/");
     var filename = p[p.length-1];
-	console.log('filename:' + filename);
+
     if(filename == "analytics") {
 
         var guidance_text = '<div class="center-alert-info">' +
@@ -16,5 +15,5 @@
         $('.course_graphs').before(guidance_text);
 
     }
-//});
+
 

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -30,7 +30,7 @@ function initAnalyticsTextBlock(){
 
 			var $target = $(mutation.target);
 
-			if ($('#analytics_body').length != 0 && $target.find('.course_graphs').length != 0) {
+			if ($target.find('.course_graphs').length != 0) {
 
 				addAnalyticsTextBlock();
             }

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -1,21 +1,23 @@
 
-function addAnalyticsText() {
-	var p = window.location.pathname.split("/");
-	var filename = p[p.length - 1];
+// get the name of the current page
+var p = window.location.pathname.split("/");
+var filename = p[p.length - 1];
 
-	if (filename == "analytics") {
+// if we are on the analytics page display the analytics text block
+if (filename == "analytics") {
 
-		var guidance_text = '<div class="center-alert-info">' +
-			'	<div class="alert-info">' +
-			'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
-			' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
-			' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
-			'	</div>' +
-			'</div>';
+	var guidance_text = '<div class="center-alert-info">' +
+		'	<div class="alert-info">' +
+		'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
+		' 		<a href="https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas" target="_blank">' +
+		' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
+		'	</div>' +
+		'</div>';
 
-		$('.course_graphs').before(guidance_text);
+	// place the text block above the graphs on the page
+	$('.course_graphs').before(guidance_text);
 
-	}
 }
 
-;$(document).ready(addAnalyticsText);
+
+

--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -28,13 +28,17 @@ function initAnalyticsTextBlock(){
     var analyticsObserver = new MutationObserver(function (mutations) {
         mutations.forEach(function (mutation) {
 
-			var $target = $(mutation.target);
+			if( $('.center-alert-info').length == 0) {
 
-			if ($target.find('div.course_graphs').length != 0) {
+				var $target = $(mutation.target);
 
-				//addAnalyticsTextBlock();
-				console.log(mutation);
-            }
+				if ($target.find('.course_graphs').length != 0) {
+
+					addAnalyticsTextBlock();
+					//console.log(mutation);
+				}
+
+			}
         });
     });
 


### PR DESCRIPTION
This PR adds a text block to the course analytics page in Canvas. 
The related story is TLT-1873:
[
Add a note on the Analytics dashboard in Canvas that says:

"The Faculty Oversight Committee on the Access to Electronic Information provides <link>guidance to faculty</link> on using these analytics."

link goes to this Harvard Guide page: https://wiki.harvard.edu/confluence/display/canvas/Electronic+Information+in+Canvas
]
