### PR TITLE
supports loading iframe resizer jquery library by CDN so course info …

### DIFF
--- a/js/iframe_resizer.js
+++ b/js/iframe_resizer.js
@@ -1,0 +1,24 @@
+;((function() {
+
+  function inPath(substring) {
+    return window.location.pathname.indexOf(substring);
+  }
+
+  function onCourseInfoIframePage() {
+    if (inPath('syllabus') || inPath('pages')) {
+      return $('div#content').find('iframe[title="Course Info"]').length;
+    }
+    return false;
+  }
+
+  // If we're on a page with the course info iframe, set up bidirectional
+  // messaging to keep iframe size in sync with embedded document size
+  ((function init() {
+    if (onCourseInfoIframePage()) {
+      require(['jquery', 'https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.1/iframeResizer.min.js'], function() {
+        $('iframe[title="Course Info"]').iFrameResize();
+      });
+    }
+  })());
+
+})());


### PR DESCRIPTION
Uses a larger, more robust library to monitor page changes and resize iframe dynamically (advantage: can support changing window size, and older browsers -- also a more robust and well-tested package so hopefully less potential bugs on different platforms and browsers; disadvantage: large amount of code to include in global.js).

This branch loads the resizer library by CDN, and otherwise is very similar to https://github.com/harvard-canvas-branding/canvas-branding-global/pull/21

Companion code required in canvas_course_info: 
- https://github.com/Harvard-ATG/canvas_course_info/pull/12
