### PR TITLE
the date picker field for course conclude should be be disabled. The …

### DIFF
--- a/js/course_settings_disable_course_conclude.js
+++ b/js/course_settings_disable_course_conclude.js
@@ -52,6 +52,8 @@ function initHUGlobal() {
         disableCourseUnconcludeButton();
         addCourseUnconcludeButtonDisabledMessage();
     }
+    
+    addCourseConcludeDateDisabledMessage();
 
     // datepicker is not always available on document.ready(), and doesn't
     // trigger mutations when added to DOM, so we have to track when it gets
@@ -62,7 +64,6 @@ function initHUGlobal() {
         if ($target.not('.datepickerDisabled').hasClass('hasDatepicker')) {
           $target.addClass('datepickerDisabled');
           disableCourseConcludeDate();
-          addCourseConcludeDateDisabledMessage();
         }
       })
     });
@@ -71,8 +72,8 @@ function initHUGlobal() {
     var $content = $('#content');
     if ($content.length > 0) {
       classAttrObserver.observe($content.get(0), {
-        childList: false,
-        subtree: false,
+        childList: true,
+        subtree: true,
         attributes: true,
         characterData: false,
         attributeFilter: ['class']


### PR DESCRIPTION
…issue here was the context of the mutation observer, when it was changed to #content, the type of mutation observed needs to look at the child list. I am still a little unclear on how these work, but this seems to have fixed it. 

also, the disable date message text was being displayed twice as a result of the mutation around the datepicker. Since it's always going to be displayed and is not tied to a mutation, I moved it out of the mutation loop. 
