### PR TITLE
Task/eparker71/tlt 2197 conclude date not being disabled

### DIFF
--- a/js/course_settings_disable_course_conclude.js
+++ b/js/course_settings_disable_course_conclude.js
@@ -74,8 +74,8 @@ function initHUGlobal() {
     if ($content.length > 0) {
       classAttrObserver.observe($content.get(0), {
         childList: true,
-        subtree: false,
-        attributes: true,
+        subtree: true,
+        attributes: false,
         characterData: false,
         attributeFilter: ['class']
       });

--- a/js/course_settings_disable_course_conclude.js
+++ b/js/course_settings_disable_course_conclude.js
@@ -75,7 +75,7 @@ function initHUGlobal() {
       classAttrObserver.observe($content.get(0), {
         childList: true,
         subtree: true,
-        attributes: false,
+        attributes: true,
         characterData: false,
         attributeFilter: ['class']
       });

--- a/js/course_settings_disable_course_conclude.js
+++ b/js/course_settings_disable_course_conclude.js
@@ -7,7 +7,9 @@ function addCourseConcludeButtonDisabledMessage() {
 
 function addCourseConcludeDateDisabledMessage() {
   var msg = '(Please contact your local academic support staff to change the course conclude date)';
-  $('#course_conclude_at').closest('tr').find('div.aside').after('<p><em>' + msg + '</em></p>');
+  if ( ! $('#course_conclude_at').closest('tr').find('p') ) {
+    $('#course_conclude_at').closest('tr').find('div.aside').after('<p><em>' + msg + '</em></p>');
+  }
 }
 
 function addCourseUnconcludeButtonDisabledMessage() {

--- a/js/course_settings_disable_course_conclude.js
+++ b/js/course_settings_disable_course_conclude.js
@@ -67,6 +67,7 @@ function initHUGlobal() {
           $target.addClass('datepickerDisabled');
           disableCourseConcludeDate();
           addCourseConcludeDateDisabledMessage();
+          classAttrObserver.disconnect();
         }
       })
     });

--- a/js/course_settings_disable_course_conclude.js
+++ b/js/course_settings_disable_course_conclude.js
@@ -7,7 +7,7 @@ function addCourseConcludeButtonDisabledMessage() {
 
 function addCourseConcludeDateDisabledMessage() {
   var msg = '(Please contact your local academic support staff to change the course conclude date)';
-  if ( ! $('#course_conclude_at').closest('tr').find('p') ) {
+  if ( $('#course_conclude_at').closest('tr').find('p').length == 0 ) {
     $('#course_conclude_at').closest('tr').find('div.aside').after('<p><em>' + msg + '</em></p>');
   }
 }

--- a/js/course_settings_disable_course_conclude.js
+++ b/js/course_settings_disable_course_conclude.js
@@ -73,8 +73,8 @@ function initHUGlobal() {
     var $content = $('#content');
     if ($content.length > 0) {
       classAttrObserver.observe($content.get(0), {
-        childList: false,
-        subtree: true,
+        childList: true,
+        subtree: false,
         attributes: true,
         characterData: false,
         attributeFilter: ['class']

--- a/js/course_settings_disable_course_conclude.js
+++ b/js/course_settings_disable_course_conclude.js
@@ -53,7 +53,7 @@ function initHUGlobal() {
         addCourseUnconcludeButtonDisabledMessage();
     }
     
-    addCourseConcludeDateDisabledMessage();
+
 
     // datepicker is not always available on document.ready(), and doesn't
     // trigger mutations when added to DOM, so we have to track when it gets
@@ -64,6 +64,7 @@ function initHUGlobal() {
         if ($target.not('.datepickerDisabled').hasClass('hasDatepicker')) {
           $target.addClass('datepickerDisabled');
           disableCourseConcludeDate();
+          addCourseConcludeDateDisabledMessage();
         }
       })
     });
@@ -72,7 +73,7 @@ function initHUGlobal() {
     var $content = $('#content');
     if ($content.length > 0) {
       classAttrObserver.observe($content.get(0), {
-        childList: true,
+        childList: false,
         subtree: true,
         attributes: true,
         characterData: false,


### PR DESCRIPTION
updated code to only show conclude date message when conclude date is present on screen and only show the message once. 

Multiple mutation occur for the item course_conclude_at which caused the message to be displayed multiple times. 
