### PR TITLE
Task/eparker71/tlt 2188 hide add course and add user buttons

### DIFF
--- a/js/account_settings_disable_add_user_and_course.js
+++ b/js/account_settings_disable_add_user_and_course.js
@@ -1,34 +1,35 @@
 function isAddUserButtonPresent(){
-    $btn = $('a.add_user_link');
+    $btn = $('#right-side > div.rs-margin-all > a.add_user_link.btn.button-sidebar-wide');
     return $btn.length > 0;
 }
 
 function isAddCourseButtonPresent(){
-    $btn = $('a.add_course_link');
+    $btn = $('#right-side > div.rs-margin-all > a.add_course_link.btn.button-sidebar-wide');
     return $btn.length > 0;
 }
 
 function disableAddUserButton(){
   // remove the href asd well so people can't get the url
   // and try it directly
-  $('a.add_user_link').removeAttr("href").addClass('disabled');
+  $('#right-side > div.rs-margin-all > a.add_user_link.btn.button-sidebar-wide').removeAttr("href").addClass('disabled');
 }
 
 function disableAddCourseButton(){
   // remove the href asd well so people can't get the url
   // and try it directly
-  $('a.add_course_link').removeAttr('href').addClass('disabled');
+  $('#right-side > div.rs-margin-all > a.add_course_link.btn.button-sidebar-wide').removeAttr('href').addClass('disabled');
 }
 
 function initDisableAddUserCourse() {
   // These button appear on multiple pages in the account area.
   // So far I have found them on the root account page, the settings page,
   // and the users page. There could be other pages as well.
-  var reAccountPage = /accounts\/.+?/;
-  var windowUrl = window.location.pathname;
-  var onAccountPage = (windowUrl.search(reAccountPage) != -1);
 
-  if (onAccountPage) {
+  //var reAccountPage = /accounts\/.+?/;
+  //var windowUrl = window.location.pathname;
+  //var onAccountPage = (windowUrl.search(reAccountPage) != -1);
+
+  if ($("body[class*=context-account_]")) {
     if (isAddUserButtonPresent()) {
       disableAddUserButton();
     }

--- a/js/account_settings_disable_add_user_and_course.js
+++ b/js/account_settings_disable_add_user_and_course.js
@@ -1,22 +1,29 @@
 function isAddUserButtonPresent(){
-    $btn =$('a.add_user_link');
+    $btn = $('a.add_user_link');
     return $btn.length > 0;
 }
 
 function isAddCourseButtonPresent(){
-    $btn =$('a.add_course_link');
+    $btn = $('a.add_course_link');
     return $btn.length > 0;
 }
 
 function disableAddUserButton(){
+  // remove the href asd well so people can't get the url
+  // and try it directly
   $('a.add_user_link').removeAttr("href").addClass('disabled');
 }
 
 function disableAddCourseButton(){
+  // remove the href asd well so people can't get the url
+  // and try it directly
   $('a.add_course_link').removeAttr('href').addClass('disabled');
 }
 
 function initDisableAddUserCourse() {
+  // These button appear on multiple pages in the account area.
+  // So far I have found them on the root account page, the settings page,
+  // and the users page. There could be other pages as well.
   var reAccountPage = /accounts\/.+?/;
   var windowUrl = window.location.pathname;
   var onAccountPage = (windowUrl.search(reAccountPage) != -1);
@@ -25,6 +32,7 @@ function initDisableAddUserCourse() {
     if (isAddUserButtonPresent()) {
       disableAddUserButton();
     }
+
     if(isAddCourseButtonPresent()){
       disableAddCourseButton();
     }

--- a/js/account_settings_disable_add_user_and_course.js
+++ b/js/account_settings_disable_add_user_and_course.js
@@ -11,13 +11,13 @@ function isAddCourseButtonPresent(){
 function disableAddUserButton(){
   // remove the href asd well so people can't get the url
   // and try it directly
-  $('#right-side > div.rs-margin-all > a.add_user_link.btn.button-sidebar-wide').removeAttr("href").addClass('disabled');
+  $('#right-side > div.rs-margin-all > a.add_user_link.btn.button-sidebar-wide').removeAttr("href").addClass('disabled').attr('disabled', true);
 }
 
 function disableAddCourseButton(){
   // remove the href asd well so people can't get the url
   // and try it directly
-  $('#right-side > div.rs-margin-all > a.add_course_link.btn.button-sidebar-wide').removeAttr('href').addClass('disabled');
+  $('#right-side > div.rs-margin-all > a.add_course_link.btn.button-sidebar-wide').removeAttr('href').addClass('disabled').attr('disabled', true);
 }
 
 function initDisableAddUserCourse() {

--- a/js/account_settings_disable_add_user_and_course.js
+++ b/js/account_settings_disable_add_user_and_course.js
@@ -1,0 +1,34 @@
+function isAddUserButtonPresent(){
+    $btn =$('a.add_user_link');
+    return $btn.length > 0;
+}
+
+function isAddCourseButtonPresent(){
+    $btn =$('a.add_course_link');
+    return $btn.length > 0;
+}
+
+function disableAddUserButton(){
+  $('a.add_user_link').removeAttr("href").addClass('disabled');
+}
+
+function disableAddCourseButton(){
+  $('a.add_course_link').removeAttr('href').addClass('disabled');
+}
+
+function initDisableAddUserCourse() {
+  var reAccountPage = /accounts\/.+?\/.+?/;
+  var windowUrl = window.location.pathname;
+  var onAccountPage = (windowUrl.search(reAccountSettingsPage) != -1);
+
+  if (onAccountPage) {
+    if (isAddUserButtonPresent()) {
+      disableAddUserButton();
+    }
+    if(isAddCourseButtonPresent()){
+      disableAddCourseButton();
+    }
+  }
+}
+
+$(document).ready(initDisableAddUserCourse);

--- a/js/account_settings_disable_add_user_and_course.js
+++ b/js/account_settings_disable_add_user_and_course.js
@@ -11,13 +11,13 @@ function isAddCourseButtonPresent(){
 function disableAddUserButton(){
   // remove the href asd well so people can't get the url
   // and try it directly
-  $('#right-side > div.rs-margin-all > a.add_user_link.btn.button-sidebar-wide').removeAttr("href").addClass('disabled').attr('disabled', true);
+  $('#right-side > div.rs-margin-all > a.add_user_link.btn.button-sidebar-wide').removeAttr("href").addClass('disabled');
 }
 
 function disableAddCourseButton(){
   // remove the href asd well so people can't get the url
   // and try it directly
-  $('#right-side > div.rs-margin-all > a.add_course_link.btn.button-sidebar-wide').removeAttr('href').addClass('disabled').attr('disabled', true);
+  $('#right-side > div.rs-margin-all > a.add_course_link.btn.button-sidebar-wide').removeAttr('href').addClass('disabled');
 }
 
 function initDisableAddUserCourse() {

--- a/js/account_settings_disable_add_user_and_course.js
+++ b/js/account_settings_disable_add_user_and_course.js
@@ -17,7 +17,7 @@ function disableAddCourseButton(){
 }
 
 function initDisableAddUserCourse() {
-  var reAccountPage = /accounts\/.+?\/.+?/;
+  var reAccountPage = /accounts\/.+?/;
   var windowUrl = window.location.pathname;
   var onAccountPage = (windowUrl.search(reAccountPage) != -1);
 

--- a/js/account_settings_disable_add_user_and_course.js
+++ b/js/account_settings_disable_add_user_and_course.js
@@ -19,7 +19,7 @@ function disableAddCourseButton(){
 function initDisableAddUserCourse() {
   var reAccountPage = /accounts\/.+?\/.+?/;
   var windowUrl = window.location.pathname;
-  var onAccountPage = (windowUrl.search(reAccountSettingsPage) != -1);
+  var onAccountPage = (windowUrl.search(reAccountPage) != -1);
 
   if (onAccountPage) {
     if (isAddUserButtonPresent()) {

--- a/js/left_nav_tool_visibility_indicator.js
+++ b/js/left_nav_tool_visibility_indicator.js
@@ -4,8 +4,7 @@ var huToolVisibilityRestricted = [
   "A/B Testing Tool",
   "Manage People",
   "Manage Sections",
-  "Course Emailer",
-  "Import iSites Content"
+  "Course Emailer"
 ];
 
 function huFuzzyVisUpdate(tool){

--- a/js/left_nav_tool_visibility_indicator.js
+++ b/js/left_nav_tool_visibility_indicator.js
@@ -4,7 +4,8 @@ var huToolVisibilityRestricted = [
   "A/B Testing Tool",
   "Manage People",
   "Manage Sections",
-  "Course Emailer"
+  "Course Emailer",
+  "Import iSites Content"
 ];
 
 function huFuzzyVisUpdate(tool){


### PR DESCRIPTION
disable the add user and add course buttons in the account area of Canvas. 

These button appear on multiple pages in the account area.
So far I have found them on the root account page, the settings page,
and the users page. 
