### PR TITLE
Sprint 48: TLT-1870 - manage course link marked as restricted

### DIFF
--- a/js/left_nav_tool_visibility_indicator.js
+++ b/js/left_nav_tool_visibility_indicator.js
@@ -2,10 +2,9 @@
 var huToolVisibilityRestricted = [
   // Course-level
   "A/B Testing Tool",
-  "Manage People",
-  "Manage Sections",
   "Course Emailer",
-  "Import iSites Content"
+  "Import iSites Content",
+  "Manage Course",
 ];
 
 function huFuzzyVisUpdate(tool){


### PR DESCRIPTION
- also removes Manage People and Manage Sections entries in the restricted visibility list, as they should not exist in parallel with the new Manage Course tool
