### PR TITLE
Sort term lists

### DIFF
--- a/js/sort_term_dropdowns.js
+++ b/js/sort_term_dropdowns.js
@@ -1,14 +1,4 @@
 
-function isTermDropdownPresent(){
-  termDropdown = $('select[name="enrollment_term_id"]');
-  return termDropdown.length > 0;
-}
-
-function isTermTablePresent(){
-  termTable = $('table#terms');
-  return termTable.length > 0;
-}
-
 function sortTermDropdown(){
   var termSelect = $('select[name="enrollment_term_id"]');
   var selectedOption = $(termSelect).val();
@@ -16,19 +6,26 @@ function sortTermDropdown(){
   var re_letter = /^[A-Za-z]/;
   var re_number = /^[0-9]/;
 
-  var topList = new Array;
-  var middleList = new Array;
-  var bottomList = new Array;
+  var topList = new Array();
+  var middleList = new Array();
+  var bottomList = new Array();
 
   for (var i=0; i < termSelectList.length; i++) {
     if (termSelectList[i].label == 'All Terms') {
+      // this should be the first item in the list
+      topList.unshift(termSelectList[i]);
+    }
+    else if (termSelectList[i].label == 'Ongoing') {
+      // this should be the second item in the list
       topList.push(termSelectList[i]);
     }
     else if (termSelectList[i].label.match(re_letter)) {
+      // all other items that start with a letter will go at the bottom, sorted ascending
       bottomList.push(termSelectList[i]);
     }
     else {
-      middleList.push(termSelectList[i])
+      // all of the items that start with a number will go below the first two items, sorted descending
+      middleList.push(termSelectList[i]);
     }
   }
 
@@ -41,8 +38,6 @@ function sortTermDropdown(){
     })
   );
   $(termSelect).html(newList).val(selectedOption);
-
-  //$('select[name="enrollment_term_id"] option:eq(0)').prop('selected',true);
 }
 
 function sortTermTable(){
@@ -54,9 +49,11 @@ function sortTermTable(){
 
   for (var i=0; i < termRowList.length; i++) {
     if (termRowList[i].getElementsByClassName('name')[0].innerHTML.match(re_number)) {
+      // all of the term labels that start with a number are at the top, sorted descending
       topList.push(termRowList[i]);
     }
     else {
+      // term labels that start with a letter are at the bottom, sorted ascending
       bottomList.push(termRowList[i]);
     }
   }
@@ -79,10 +76,10 @@ function sortTermTable(){
 }
 
 $(document).ready(function() {
-  if (isTermDropdownPresent()) {
+  if ($('select[name="enrollment_term_id"]').length > 0) {
     sortTermDropdown();
   }
-  if (isTermTablePresent()) {
+  if ($('table#terms').length > 0) {
     sortTermTable();
   }
 });

--- a/js/sort_term_dropdowns.js
+++ b/js/sort_term_dropdowns.js
@@ -5,24 +5,37 @@ function isTermDropdownPresent(){
 }
 
 function sortTermDropdown(){
-  var selectList = $('select[name="enrollment_term_id"] option');
+  var termSelectList = $('select[name="enrollment_term_id"]');
 
   var re_letter = /^[A-Za-z]/;
   var re_number = /^[0-9]/;
-  selectList.sort(function(a,b){
-      // 'All Terms' at the top; other labels beggining with a letter at the end
-      if (a.label == 'All Terms') {
-        return -1;
-      }
-      if ( a.label.match(re_letter) && b.label.match(re_number) ) {
-        return 1;
-      }
-      if ( a.label.match(re_number) && b.label.match(re_letter) ) {
-        return -1;
-      }
-      return (a.label >= b.label) ? -1 : 1;
+
+  var topList = new Array;
+  var middleList = new Array;
+  var bottomList = new Array;
+
+  for (var i=0; i < termSelectList.options.length; i++) {
+    if (termSelectList.options[i].label == 'All Terms') {
+      topList.push(termSelectList.options[i]);
+    }
+    else if (termSelectList.options[i].label.match(re_letter)) {
+      bottomList.push(termSelectList.options[i]);
+    }
+    else {
+      middleList.push(termSelectList.options[i])
+    }
+  }
+
+  var newList = new Array;
+  newList += topList;
+  newList += middleList.sort(function(a,b){
+    return (a.label >= b.label) ? -1 : 1;
   });
-  $('select[name="enrollment_term_id"]').html(selectList);
+  newList += bottomList.sort(function(a,b){
+    return (a.label >= b.label) ? -1 : 1;
+  });
+
+  $('select[name="enrollment_term_id"]').html(newList);
 }
 
 function initSortTermDropdown() {

--- a/js/sort_term_dropdowns.js
+++ b/js/sort_term_dropdowns.js
@@ -17,6 +17,9 @@ function sortTermDropdown(){
       if ( a.label.match(re_letter) && b.label.match(re_number) ) {
         return 1;
       }
+      if ( a.label.match(re_number) && b.label.match(re_letter) ) {
+        return -1;
+      }
       return (a.label >= b.label) ? -1 : 1;
   });
   $('select[name="enrollment_term_id"]').html(selectList);

--- a/js/sort_term_dropdowns.js
+++ b/js/sort_term_dropdowns.js
@@ -1,11 +1,18 @@
 
 function isTermDropdownPresent(){
-  $termDropdown =$('select[name="enrollment_term_id"]');
-  return $termDropdown.length > 0;
+  termDropdown = $('select[name="enrollment_term_id"]');
+  return termDropdown.length > 0;
+}
+
+function isTermTablePresent(){
+  termTable = $('table#terms');
+  return termTable.length > 0;
 }
 
 function sortTermDropdown(){
-  var termSelectList = $('select[name="enrollment_term_id"] option');
+  var termSelect = $('select[name="enrollment_term_id"]');
+  var selectedOption = $(termSelect).val();
+  var termSelectList = $('option', termSelect);
   var re_letter = /^[A-Za-z]/;
   var re_number = /^[0-9]/;
 
@@ -33,14 +40,49 @@ function sortTermDropdown(){
       return (a.label >= b.label) ? 1 : -1;
     })
   );
-  $('select[name="enrollment_term_id"]').html(newList);
-  $('select[name="enrollment_term_id"] option:eq(0)').prop('selected',true);
+  $(termSelect).html(newList).val(selectedOption);
+
+  //$('select[name="enrollment_term_id"] option:eq(0)').prop('selected',true);
 }
 
-function initSortTermDropdown() {
+function sortTermTable(){
+  var termRowList = $('table#terms tbody tr.term').get();
+  var re_letter = /^[A-Za-z]/;
+  var re_number = /^[0-9]/;
+  var topList = new Array;
+  var bottomList = new Array;
+
+  for (var i=0; i < termRowList.length; i++) {
+    if (termRowList[i].getElementsByClassName('name')[0].innerHTML.match(re_number)) {
+      topList.push(termRowList[i]);
+    }
+    else {
+      bottomList.push(termRowList[i]);
+    }
+  }
+
+  var newList = topList.sort(function(a,b){
+      var alabel = a.getElementsByClassName('name')[0].innerHTML;
+      var blabel = b.getElementsByClassName('name')[0].innerHTML;
+
+      return (alabel >= blabel) ? -1 : 1;
+    }).concat(
+      bottomList.sort(function(a,b){
+        var alabel = a.getElementsByClassName('name')[0].innerHTML;
+        var blabel = b.getElementsByClassName('name')[0].innerHTML;
+        return (alabel >= blabel) ? 1 : -1;
+      })
+    );
+
+  $('table#terms').children('tbody').append(newList);
+
+}
+
+$(document).ready(function() {
   if (isTermDropdownPresent()) {
     sortTermDropdown();
   }
-}
-
-$(document).ready(initSortTermDropdown);
+  if (isTermTablePresent()) {
+    sortTermTable();
+  }
+});

--- a/js/sort_term_dropdowns.js
+++ b/js/sort_term_dropdowns.js
@@ -1,0 +1,31 @@
+
+function isTermDropdownPresent(){
+  $termDropdown =$('select[name="enrollment_term_id"]');
+  return $termDropdown.length > 0;
+}
+
+function sortTermDropdown(){
+  var selectList = $('select[name="enrollment_term_id"] option');
+
+  var re_letter = /^[A-Za-z]/;
+  var re_number = /^[0-9]/;
+  selectList.sort(function(a,b){
+      // 'All Terms' at the top; other labels beggining with a letter at the end
+      if (a.label == 'All Terms') {
+        return -1;
+      }
+      if ( a.label.match(re_letter) && b.label.match(re_number) ) {
+        return 1;
+      }
+      return (a.label >= b.label) ? -1 : 1;
+  });
+  $('select[name="enrollment_term_id"]').html(selectList);
+}
+
+function initSortTermDropdown() {
+  if (isTermDropdownPresent()) {
+    sortTermDropdown();
+  }
+}
+
+$(document).ready(initSortTermDropdown);

--- a/js/sort_term_dropdowns.js
+++ b/js/sort_term_dropdowns.js
@@ -5,8 +5,7 @@ function isTermDropdownPresent(){
 }
 
 function sortTermDropdown(){
-  var termSelectList = $('select[name="enrollment_term_id"]');
-
+  var termSelectList = $('select[name="enrollment_term_id"] option');
   var re_letter = /^[A-Za-z]/;
   var re_number = /^[0-9]/;
 
@@ -14,28 +13,28 @@ function sortTermDropdown(){
   var middleList = new Array;
   var bottomList = new Array;
 
-  for (var i=0; i < termSelectList.options.length; i++) {
-    if (termSelectList.options[i].label == 'All Terms') {
-      topList.push(termSelectList.options[i]);
+  for (var i=0; i < termSelectList.length; i++) {
+    if (termSelectList[i].label == 'All Terms') {
+      topList.push(termSelectList[i]);
     }
-    else if (termSelectList.options[i].label.match(re_letter)) {
-      bottomList.push(termSelectList.options[i]);
+    else if (termSelectList[i].label.match(re_letter)) {
+      bottomList.push(termSelectList[i]);
     }
     else {
-      middleList.push(termSelectList.options[i])
+      middleList.push(termSelectList[i])
     }
   }
 
-  var newList = new Array;
-  newList += topList;
-  newList += middleList.sort(function(a,b){
-    return (a.label >= b.label) ? -1 : 1;
-  });
-  newList += bottomList.sort(function(a,b){
-    return (a.label >= b.label) ? -1 : 1;
-  });
-
+  var newList = topList.concat(
+    middleList.sort(function(a,b){
+      return (a.label >= b.label) ? -1 : 1;
+    }),
+    bottomList.sort(function(a,b){
+      return (a.label >= b.label) ? 1 : -1;
+    })
+  );
   $('select[name="enrollment_term_id"]').html(newList);
+  $('select[name="enrollment_term_id"] option:eq(0)').prop('selected',true);
 }
 
 function initSortTermDropdown() {


### PR DESCRIPTION
This PR adds a new JS file that will help make the Canvas UI more usable by admins by sorting terms by their labels. The term dropdown list on the account courses page and the table on the account terms page will be sorted in a way that should make it easier to find specific entries. 

This custom JS is currently installed in our test instance of Canvas. 
