### PR TITLE
Removing the font-family rule to let the font that's specified in Can…

### DIFF
--- a/css/analytics_text.css
+++ b/css/analytics_text.css
@@ -20,7 +20,6 @@ named using tlt-analytics as a prefix to avoid clashing with Canvas styles.
      background-repeat: repeat-x;
      border-radius: 4px;
      border: solid 1px #9acfea;
-     font-family: Helvetica, Arial, sans-serif;
      text-align: center; display: inline-block;
      width: 60%;
      margin: 1em 0.5em 2% 1em;


### PR DESCRIPTION
…vas-native CSS take effect.

Tested on https://harvard.test.instructure.com/courses/34/analytics (Note that analytics is not installed on canvas.dev)

Attaching screenshots from before and after:
<img width="1124" alt="screen shot 2017-02-17 at 2 45 46 pm" src="https://cloud.githubusercontent.com/assets/1084105/23082582/fe3b2758-f527-11e6-8ac6-0ed23e3408a8.png">

<img width="1212" alt="screen shot 2017-02-17 at 3 38 55 pm" src="https://cloud.githubusercontent.com/assets/1084105/23082589/0aaa40dc-f528-11e6-88d4-b95e2b76858e.png">

After:
<img width="1101" alt="screen shot 2017-02-17 at 3 38 10 pm" src="https://cloud.githubusercontent.com/assets/1084105/23082599/10a3208a-f528-11e6-8b05-2599753f978c.png">

<img width="1214" alt="screen shot 2017-02-17 at 3 39 12 pm" src="https://cloud.githubusercontent.com/assets/1084105/23082604/1508459c-f528-11e6-9eba-0e32aaec348a.png">

