### PR TITLE
Task/thornton/tlt 3153/remove speedgrader warning

### DIFF
--- a/css/speedgrader.css
+++ b/css/speedgrader.css
@@ -1,4 +1,0 @@
-#hu-autosave-warning {
-    /* override ic-flash-error z-index so #combo_box_container student dropdown isn't overlaid by error msg */
-    z-index: inherit;
-}

--- a/js/speedgrader.js
+++ b/js/speedgrader.js
@@ -1,9 +1,0 @@
-$(document).ready(function(){
-    if ($.browser.mozilla && window.location.href.indexOf('gradebook/speed_grader') > -1) {
-        $('#left_side_inner').prepend(
-            '<div id="hu-autosave-warning" class="ic-flash-error">' +
-            'Warning for Firefox users: assignment comments will not be saved automatically -- you must click outside the comment box to save your last entry before navigating to another page. Please use another browser such as Chrome to take advantage of automatic saving.' +
-            '</div>'
-        );
-    };
-});


### PR DESCRIPTION
[TLT-3153](https://jira.huit.harvard.edu/browse/TLT-3153)

Removed the speedgrader js and css files which contained the unwanted error message.

Jenkins deployed this branch and uploaded the js and css files to a new  ['Harvard Theme Warning Removal' theme](https://harvard.test.instructure.com/accounts/1/brand_configs?theme_applied=1).

Attached to this is the global.min.css and global.min.js files from that build.
[global_files.zip](https://github.com/harvard-canvas-branding/canvas-branding-global/files/1140187/global_files.zip)

Open the following link in Firefox to verify that the message is not displayed:
https://harvard.test.instructure.com/courses/11193/gradebook/speed_grader?assignment_id=81033#%7B%22student_id%22%3A%22127959%22%7D