### PR TITLE
Update copyright year to be a range

### DIFF
--- a/js/footer_copyright.js
+++ b/js/footer_copyright.js
@@ -8,7 +8,7 @@ $(document).ready(function(e) {
     var copyYear = new Date().getFullYear();
 
     var harvardCopy =
-        '<div>Copyright &copy; ' + copyYear + ' The President and Fellows of Harvard College | ' +
+        '<div>Copyright &copy; 2013-' + copyYear + ' The President and Fellows of Harvard College | ' +
         '<a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=3373044ddb4d57cc83a2f3f7bf961909" id="privacy_policy_link" target="_blank">Privacy Policy</a> | ' +
         '<a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=9d718485db0d57cc83a2f3f7bf961902" id="acceptable_use_policy_link" target="_blank">Acceptable Use Policy</a>' +
         '</div>';

--- a/js/footer_copyright.js
+++ b/js/footer_copyright.js
@@ -5,8 +5,10 @@ $(document).ready(function(e) {
      * enough.  also, wrapping things in <p> tags doesn't get you multiple
      * lines
      */
+    var copyYear = new Date().getFullYear();
+
     var harvardCopy =
-        '<div>Copyright &copy; 2018 The President and Fellows of Harvard College | ' +
+        '<div>Copyright &copy; ' + copyYear + ' The President and Fellows of Harvard College | ' +
         '<a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=3373044ddb4d57cc83a2f3f7bf961909" id="privacy_policy_link" target="_blank">Privacy Policy</a> | ' +
         '<a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=9d718485db0d57cc83a2f3f7bf961902" id="acceptable_use_policy_link" target="_blank">Acceptable Use Policy</a>' +
         '</div>';


### PR DESCRIPTION
This PR updates the copyright year to be a range starting with 2013 (when we started using this instance) and the current year. It will update dynamically going forward.