### PR TITLE
Feature/update hidden nav formatting

### DIFF
--- a/js/left_nav_tool_visibility_indicator.js
+++ b/js/left_nav_tool_visibility_indicator.js
@@ -11,18 +11,16 @@ var huToolVisibilityRestricted = [
 
 function huFuzzyVisUpdate(tool){
   return $("div[id='left-side'] a[class^='context_external_tool']:contains('"+ tool + "')")
-    .append('<i class="nav-icon icon-off" aria-hidden="true" role="presentation"></i>')
-    // .parent().addClass('section-tab-hidden');
+    .append('<i class="nav-icon icon-off" title="Not visible to students"  aria-hidden="true" role="presentation"></i>')
 }
 
 function huExactVisUpdate(tool){
   return $("div[id='left-side'] a[class^='context_external_tool']")
     .filter(function(){ return $(this).text() === tool })
-    .append('<i class="nav-icon icon-off" aria-hidden="true" role="presentation"></i>')
-    // .parent().addClass('section-tab-hidden');
+    .append('<i class="nav-icon icon-off"  title="Not visible to students" aria-hidden="true" role="presentation"></i>')
 }
 
-
+  
 /*
  Changes the link style of a specified list of custom tools in the left-hand nav
   to indicate they are not visible to students (current Canvas behavior is to show

--- a/js/left_nav_tool_visibility_indicator.js
+++ b/js/left_nav_tool_visibility_indicator.js
@@ -11,20 +11,22 @@ var huToolVisibilityRestricted = [
 
 function huFuzzyVisUpdate(tool){
   return $("div[id='left-side'] a[class^='context_external_tool']:contains('"+ tool + "')")
-    .parent().addClass('section-tab-hidden');
+    .append('<i class="nav-icon icon-off" aria-hidden="true" role="presentation"></i>')
+    // .parent().addClass('section-tab-hidden');
 }
 
 function huExactVisUpdate(tool){
   return $("div[id='left-side'] a[class^='context_external_tool']")
     .filter(function(){ return $(this).text() === tool })
-    .parent().addClass('section-tab-hidden');
+    .append('<i class="nav-icon icon-off" aria-hidden="true" role="presentation"></i>')
+    // .parent().addClass('section-tab-hidden');
 }
 
 
 /*
  Changes the link style of a specified list of custom tools in the left-hand nav
   to indicate they are not visible to students (current Canvas behavior is to show
-  the link text in grey).
+  an icon to the right of the text).
   toolList: Array of strings representing the link text of all
             tools that need to be marked as visible only to admins.
   exactMatch: If true, will only match tool links with the exact names in toolList.

--- a/js/left_nav_tool_visibility_indicator.js
+++ b/js/left_nav_tool_visibility_indicator.js
@@ -8,19 +8,21 @@ var huToolVisibilityRestricted = [
   "Import iSites Content",
   "Manage Course",
 ];
-
 function huFuzzyVisUpdate(tool){
-  return $("div[id='left-side'] a[class^='context_external_tool']:contains('"+ tool + "')")
-    .append('<i class="nav-icon icon-off" title="Not visible to students"  aria-hidden="true" role="presentation"></i>')
+	var element = $("div[id='left-side'] a[class^='context_external_tool']:contains('"+ tool + "')");
+	//modify the title and append the icon
+	element.attr("title", "Not visible to students");
+	return element.append('<i class="nav-icon icon-off" title="Not visible to students"  aria-hidden="true" role="presentation"></i>')
 }
 
 function huExactVisUpdate(tool){
-  return $("div[id='left-side'] a[class^='context_external_tool']")
-    .filter(function(){ return $(this).text() === tool })
-    .append('<i class="nav-icon icon-off"  title="Not visible to students" aria-hidden="true" role="presentation"></i>')
+	var element = $("div[id='left-side'] a[class^='context_external_tool']")
+    .filter(function(){ return $(this).text() === tool });
+	//modify the title and append the icon
+	element.attr("title", "Not visible to students");
+  	return element.append('<i class="nav-icon icon-off"  title="Not visible to students" aria-hidden="true" role="presentation"></i>')
 }
 
-  
 /*
  Changes the link style of a specified list of custom tools in the left-hand nav
   to indicate they are not visible to students (current Canvas behavior is to show


### PR DESCRIPTION
This PR has changes to update Canvas navigation custom formatting to match new format. It has the has the eyeball icon addition, but the tooltip is partially consistent. It doesn't have the same style but has a title indicating that it is hidden from students.

Deployed on Beta and tested on : https://harvard.beta.instructure.com/courses/42049/modules