### PR TITLE
TLT-4055 Make Account Path Clickable

### DIFF
--- a/js/course_settings_add_school_detail.js
+++ b/js/course_settings_add_school_detail.js
@@ -35,7 +35,7 @@ function handleResponse(response) {
 
 function getAccountsPath(accounts) {
     return accounts.slice().reverse().map(function(account) {
-        return '<a href="'+window.location.origin+'/accounts/'+account.id+'">'+account.name+'</a>';
+        return '<a href="/accounts/'+account.id+'">'+account.name+'</a>';
     }).join(" > ");
 }
 

--- a/js/course_settings_add_school_detail.js
+++ b/js/course_settings_add_school_detail.js
@@ -35,7 +35,7 @@ function handleResponse(response) {
 
 function getAccountsPath(accounts) {
     return accounts.slice().reverse().map(function(account) {
-        return account.name;
+        return '<a href="'+window.location.origin+'/accounts/'+account.id+'">'+account.name+'</a>';
     }).join(" > ");
 }
 
@@ -51,7 +51,7 @@ function annotatePage(text, style) {
         span.style.backgroundColor = style.backgroundColor;
         span.style.padding = ".5em";
         span.style.marginBottom = "1em";
-        span.appendChild(document.createTextNode(text));
+        span.innerHTML=text;
         el.parentNode.appendChild(span);
     }
     return el;


### PR DESCRIPTION
Makes the breadcrumb of accounts in a course settings page clickable to bring you to the desired account page.
Currently deployed on https://canvas.qa.tlt.harvard.edu/