### PR TITLE
TLT-4280: Update guidance link on Canvas Analytics page

### DIFF
--- a/js/analytics_text.js
+++ b/js/analytics_text.js
@@ -16,7 +16,7 @@ function initAnalyticsTextBlock(){
 	var guidance_text = '<div id="analytics-guidance" class="tlt-analytics-center-alert-info">' +
 	'	<div class="tlt-analytics-alert-info">' +
 	'		The Faculty Oversight Committee on the Access to Electronic Information provides' +
-	' 		<a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=dc7fa896db8d170083a2f3f7bf96198f" target="_blank">' +
+	' 		<a href="https://huit.harvard.edu/privacy/canvas#oversight" target="_blank">' +
 	' 		<strong>guidance to faculty</strong></a> on using these analytics.' +
 	'	</div>' +
 	'</div>';


### PR DESCRIPTION
Resolves [TLT-4280](https://jira.huit.harvard.edu/browse/TLT-4280).

This PR updates the link listed at the top of the Canvas Analytics page to point to a new page. Clicking on the link now leads to a HUIT-hosted page, replacing the ServiceNow link.

This change has been deployed to the Canvas Test environment and can be viewed here: https://harvard.test.instructure.com/courses/18003/external_tools/46224.