### PR TITLE
Add restricted visibility icon to Pope Tech 

### DIFF
--- a/js/left_nav_tool_visibility_indicator.js
+++ b/js/left_nav_tool_visibility_indicator.js
@@ -7,7 +7,8 @@ var huToolVisibilityRestricted = [
   "Course Emailer",
   "Import iSites Content",
   "Manage Course",
-  "HUIT Accessibility"
+  "HUIT Accessibility",
+  "Accessibility Dashboard"
 ];
 function huFuzzyVisUpdate(tool){
 	var element = $("div[id='left-side'] a[class^='context_external_tool']:contains('"+ tool + "')");

--- a/js/left_nav_tool_visibility_indicator.js
+++ b/js/left_nav_tool_visibility_indicator.js
@@ -7,6 +7,7 @@ var huToolVisibilityRestricted = [
   "Course Emailer",
   "Import iSites Content",
   "Manage Course",
+  "HUIT Accessibility"
 ];
 function huFuzzyVisUpdate(tool){
 	var element = $("div[id='left-side'] a[class^='context_external_tool']:contains('"+ tool + "')");


### PR DESCRIPTION
This PR adds the "restricted visibility" icon (eye with line through it) to the nav item for the Pope Tech accessibility tool. The code will recognize either "HUIT Accessibility" or "Accessibility Dashboard". The latter text is what we expect to go into production, but it doesn't hurt to have both in the code for now.

This is currently installed on harvard.test.instructure.com. 