### PR TITLE
Prevent loading of footer on content migrations page

### DIFF
--- a/js/footer_copyright.js
+++ b/js/footer_copyright.js
@@ -19,6 +19,10 @@ $(document).ready(function (e) {
       return;
     }
 
+    if (window.location.href.match(/\/courses\/\d+\/content_migrations.*/)) {
+      return;
+    }
+
     const copyYear = new Date().getFullYear();
 
     const harvardCopy =


### PR DESCRIPTION
Resolves [TLT-4722](https://at-harvard.atlassian.net/browse/TLT-4722).

Example of updated theme without custom footer:

![Screen Shot 2024-07-23 at 3 02 36 PM](https://github.com/user-attachments/assets/b821fbda-f054-47f3-b631-96b1d533ee01)
