### PR TITLE
No footer on assignments pages

### DIFF
--- a/js/footer_copyright.js
+++ b/js/footer_copyright.js
@@ -23,6 +23,10 @@ $(document).ready(function (e) {
       return;
     }
 
+    if (window.location.href.match(/\/courses\/\d+\/assignments.*/)) {
+      return;
+    }
+
     const copyYear = new Date().getFullYear();
 
     const harvardCopy =


### PR DESCRIPTION
The footer that we add to Canvas pages is causing formatting problems on some assignments pages. 

This PR prevents the footer from being added to Assingments pages.

Reported by faculty member in INC05876088. 